### PR TITLE
Fix/duplicate/current services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,3 @@ secrets/
 *.key
 *.pem
 *.crt
-
-# Other
-.todo

--- a/.todo
+++ b/.todo
@@ -1,0 +1,49 @@
+Todo:
+  ✘ Build custom caddy with cloudflare docker image @started(25-07-19 17:01) @cancelled(25-07-19 17:05) @wasted(4m24s)
+  ✔ Setup cloudflare with subdomains @started(25-07-19 15:16) @done(25-07-19 17:41) @lasted(2h25m8s)
+  ✔ Setup caddy file (double check) @started(25-07-19 17:41) @done(25-07-19 18:09) @lasted(28m41s)
+  ✔ Re setup caddy in docker compose for entire server @done(25-07-19 18:28)
+  ✔ Setup assets path @done(25-07-19 18:28)
+  ✔ Add a `/data` path for this project to store all data related to my homelab @done(25-07-19 18:29)
+  ✔ Setup glance properly @started(25-07-19 18:29) @done(25-07-19 19:28) @lasted(59m28s)
+  ✔ Demo if docker compose caddy setup works on mac with docker network, etc @started(25-07-19 19:28) @done(25-07-20 13:48) @lasted(18h20m27s)
+  ✔ Debug DNS issue with tailscale @done(25-08-21 17:16)
+  ✔ Setup docker container for tailscale @done(25-08-21 17:16)
+  ✔ See if you need caddy docker proxy or not @done(25-08-21 17:16)
+  ✔ Test all changes and see if it works @done(25-08-21 17:16)
+  ✔ Setup the cockpit with caddy tehe this will suck @done(25-08-21 17:16)
+  ✔ Debug issues @done(25-08-21 17:16)
+  ✔ Push to github @done(25-08-21 17:17)
+
+  ✔ Need to add the dns server ip to be persistent @done(25-08-21 17:17)
+  ✔ Add portainer to docker compose @done(25-08-21 17:17)
+  ✔ Add dokploy on other server to caddy net @done(25-08-21 17:17)
+  ✔ Setup dokploy @done(25-08-21 17:17)
+  ✔ Add dokploy to glance.yml @done(25-08-21 17:18)
+  ✔ Add dokploy to portainer @done(25-08-21 17:18)
+  ✔ Add ollama to big server @done(25-08-21 17:19)
+  ✔ Expose ollama port on big server so main server has access to it for caddy setup @done(25-08-21 17:27)
+  ✔ Fix caddy issue with ollama domain @done(25-08-21 18:04)
+  ✔ Add glance widget for server stats, and remote as well @done(25-08-21 18:23)
+  - Add Ollama to portainer @started(25-08-21 18:24)
+  - Fix ollama portainer agent so we can add it to portainer properly (stop it first it is constantly restarting)
+  Setup all media services:
+    - Setup Komga
+    - Setup Jellyfin
+    - Setup Sonarr
+    - Setup Radarr
+    - Setup Prowlarr
+    - Find a manga downloader (suwayomi if it can work)
+  - Fix podman compose going down randomly
+  - Make your own Go script for remote servers glance
+  - Add grafana for data monitoring
+  - Add gh self hosted runner to machine 2
+  - Move adguard config to this repo instead
+  - Fix ip to static for srv-nana
+
+Fix my server:
+  - Fix the ip of my computer to use the ethernet on
+  - Run all podman containers and set up dns
+  - Add all adguard rewrites back
+  - Add all portainer configs back
+  - Create glance agent to setup remote server connections

--- a/.todo
+++ b/.todo
@@ -25,7 +25,17 @@ Todo:
   ✔ Expose ollama port on big server so main server has access to it for caddy setup @done(25-08-21 17:27)
   ✔ Fix caddy issue with ollama domain @done(25-08-21 18:04)
   ✔ Add glance widget for server stats, and remote as well @done(25-08-21 18:23)
-  - Add Ollama to portainer @started(25-08-21 18:24)
+
+Fix my server:
+  ✔ Fix the ip of my computer to use the ethernet on @done(25-08-28 21:00)
+  ✔ Run all podman containers and set up dns @done(25-08-28 21:00)
+  ✔ Add all adguard rewrites back @done(25-08-28 21:00)
+  ✔ Add all portainer configs back @done(25-08-28 21:00)
+  - Fix the monitor on glance @started(25-08-28 21:02)
+  - Fix the docker containers widget on glance
+  - Create glance agent to setup remote server connections
+  - Add nextcloud back onto podman network
+  - Add Ollama to portainer
   - Fix ollama portainer agent so we can add it to portainer properly (stop it first it is constantly restarting)
   Setup all media services:
     - Setup Komga
@@ -40,10 +50,3 @@ Todo:
   - Add gh self hosted runner to machine 2
   - Move adguard config to this repo instead
   - Fix ip to static for srv-nana
-
-Fix my server:
-  - Fix the ip of my computer to use the ethernet on
-  - Run all podman containers and set up dns
-  - Add all adguard rewrites back
-  - Add all portainer configs back
-  - Create glance agent to setup remote server connections

--- a/Caddyfile
+++ b/Caddyfile
@@ -8,7 +8,7 @@ dashboard.{env.DOMAIN} {
 
 # Dokploy UI (remote server)
 dokploy.{env.DOMAIN} {
-	reverse_proxy dokploy:{env.DOKPLOY_UI_PORT}
+	reverse_proxy host.docker.internal:{env.DOKPLOY_UI_PORT}
 	tls {
 		dns cloudflare {env.CLOUDFLARE_API_TOKEN}
 	}

--- a/adguard/AdGuardHome.yaml
+++ b/adguard/AdGuardHome.yaml
@@ -1,0 +1,211 @@
+http:
+  pprof:
+    port: 6060
+    enabled: false
+  address: 0.0.0.0:8080
+  session_ttl: 720h
+users:
+  - name: geisha
+    password: $2a$10$hO..Z9DhhICpZkjRzGFlWOGyXmCAgYq/2BLNubD9ZPXv.03RAEip6
+auth_attempts: 5
+block_auth_min: 15
+http_proxy: ""
+language: ""
+theme: auto
+dns:
+  bind_hosts:
+    - 0.0.0.0
+  port: 53
+  anonymize_client_ip: false
+  ratelimit: 0
+  ratelimit_subnet_len_ipv4: 24
+  ratelimit_subnet_len_ipv6: 56
+  ratelimit_whitelist: []
+  refuse_any: true
+  upstream_dns:
+    - https://dns10.quad9.net/dns-query
+  upstream_dns_file: ""
+  bootstrap_dns:
+    - 9.9.9.10
+    - 149.112.112.10
+    - 2620:fe::10
+    - 2620:fe::fe:10
+  fallback_dns: []
+  upstream_mode: load_balance
+  fastest_timeout: 1s
+  allowed_clients: []
+  disallowed_clients: []
+  blocked_hosts:
+    - version.bind
+    - id.server
+    - hostname.bind
+  trusted_proxies:
+    - 127.0.0.0/8
+    - ::1/128
+  cache_enabled: true
+  cache_size: 4194304
+  cache_ttl_min: 0
+  cache_ttl_max: 0
+  cache_optimistic: false
+  bogus_nxdomain: []
+  aaaa_disabled: false
+  enable_dnssec: false
+  edns_client_subnet:
+    custom_ip: ""
+    enabled: false
+    use_custom: false
+  max_goroutines: 300
+  handle_ddr: true
+  ipset: []
+  ipset_file: ""
+  bootstrap_prefer_ipv6: false
+  upstream_timeout: 10s
+  private_networks: []
+  use_private_ptr_resolvers: true
+  local_ptr_upstreams: []
+  use_dns64: false
+  dns64_prefixes: []
+  serve_http3: false
+  use_http3_upstreams: false
+  serve_plain_dns: true
+  hostsfile_enabled: true
+  pending_requests:
+    enabled: true
+tls:
+  enabled: false
+  server_name: ""
+  force_https: false
+  port_https: 443
+  port_dns_over_tls: 853
+  port_dns_over_quic: 853
+  port_dnscrypt: 0
+  dnscrypt_config_file: ""
+  allow_unencrypted_doh: false
+  certificate_chain: ""
+  private_key: ""
+  certificate_path: ""
+  private_key_path: ""
+  strict_sni_check: false
+querylog:
+  dir_path: ""
+  ignored: []
+  interval: 2160h
+  size_memory: 1000
+  enabled: true
+  file_enabled: true
+statistics:
+  dir_path: ""
+  ignored: []
+  interval: 24h
+  enabled: true
+filters:
+  - enabled: true
+    url: https://adguardteam.github.io/HostlistsRegistry/assets/filter_1.txt
+    name: AdGuard DNS filter
+    id: 1
+  - enabled: false
+    url: https://adguardteam.github.io/HostlistsRegistry/assets/filter_2.txt
+    name: AdAway Default Blocklist
+    id: 2
+whitelist_filters: []
+user_rules: []
+dhcp:
+  enabled: false
+  interface_name: ""
+  local_domain_name: lan
+  dhcpv4:
+    gateway_ip: ""
+    subnet_mask: ""
+    range_start: ""
+    range_end: ""
+    lease_duration: 86400
+    icmp_timeout_msec: 1000
+    options: []
+  dhcpv6:
+    range_start: ""
+    lease_duration: 86400
+    ra_slaac_only: false
+    ra_allow_slaac: false
+filtering:
+  blocking_ipv4: ""
+  blocking_ipv6: ""
+  blocked_services:
+    schedule:
+      time_zone: UTC
+    ids: []
+  protection_disabled_until: null
+  safe_search:
+    enabled: false
+    bing: true
+    duckduckgo: true
+    ecosia: true
+    google: true
+    pixabay: true
+    yandex: true
+    youtube: true
+  blocking_mode: default
+  parental_block_host: family-block.dns.adguard.com
+  safebrowsing_block_host: standard-block.dns.adguard.com
+  rewrites:
+    - domain: dashboard.chateauducipieres.com
+      answer: 192.168.200.70
+    - domain: dokploy.chateauducipieres.com
+      answer: 192.168.200.70
+    - domain: ollama.chateauducipieres.com
+      answer: 192.168.200.70
+    - domain: admin.chateauducipieres.com
+      answer: 192.168.200.70
+    - domain: library.chateauducipieres.com
+      answer: 192.168.200.70
+    - domain: media.chateauducipieres.com
+      answer: 192.168.200.70
+    - domain: jellyseerr.chateauducipieres.com
+      answer: 192.168.200.70
+    - domain: manga.chateauducipieres.com
+      answer: 192.168.200.70
+    - domain: radarr.chateauducipieres.com
+      answer: 192.168.200.70
+    - domain: sonarr.chateauducipieres.com
+      answer: 192.168.200.70
+    - domain: prowlarr.chateauducipieres.com
+      answer: 192.168.200.70
+    - domain: drive.chateauducipieres.com
+      answer: 192.168.200.70
+    - domain: adguard.chateauducipieres.com
+      answer: 192.168.200.70
+    - domain: portainer.chateauducipieres.com
+      answer: 192.168.200.70
+  safe_fs_patterns:
+    - /opt/adguardhome/work/userfilters/*
+  safebrowsing_cache_size: 1048576
+  safesearch_cache_size: 1048576
+  parental_cache_size: 1048576
+  cache_time: 30
+  filters_update_interval: 24
+  blocked_response_ttl: 10
+  filtering_enabled: true
+  parental_enabled: false
+  safebrowsing_enabled: false
+  protection_enabled: true
+clients:
+  runtime_sources:
+    whois: true
+    arp: true
+    rdns: true
+    dhcp: true
+    hosts: true
+  persistent: []
+log:
+  enabled: true
+  file: ""
+  max_backups: 0
+  max_size: 100
+  max_age: 3
+  compress: false
+  local_time: false
+  verbose: false
+os:
+  group: ""
+  user: ""
+  rlimit_nofile: 0
+schema_version: 30

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,6 @@ services:
       - caddy_config:/config:Z
     extra_hosts:
          - host.docker.internal:host-gateway
-         - dokploy:${DOKPLOY_HOST}
          - ollama:${OLLAMA_HOST}
 
   adguardhome:  
@@ -78,7 +77,7 @@ services:
 
     volumes:  
       - adguard_config:/opt/adguardhome/work:Z  
-      - adguard_confdir:/opt/adguardhome/conf:Z  
+      - $PWD/adguard:/opt/adguardhome/conf:Z
 
 
   glance:
@@ -89,12 +88,9 @@ services:
       - caddynet
     env_file:
       - .env
-    environment:
-      - GLANCE_SECRET=${GLANCE_SECRET}
-      - GLANCE_DANIEL_PASSWORD=${GLANCE_DANIEL_PASSWORD}
     volumes:
       - ${GLANCE_PATH}/config:/app/config:Z
-      - ${ASSETS_PATH}:/app/assets
+      - ${ASSETS_PATH}:/app/assets:Z
       - /run/user/1000/podman/podman.sock:/var/run/docker.sock:z
     ports:
       - ${GLANCE_PORT}:${GLANCE_DOCKER_PORT}

--- a/glance/config/glance.yml
+++ b/glance/config/glance.yml
@@ -1,6 +1,5 @@
 server:
   proxied: true
-  assets-path: /app/assets
 auth:
   secret-key: ${GLANCE_SECRET}
   users:
@@ -23,20 +22,6 @@ theme:
       positive-color: 86 27 42 
       negative-color: 352 55 52 
       accent-color: 218 34 45 
-    
-    kanso-mist:
-      background-color: 222 13 16 
-      primary-color: 150 4 78 
-      positive-color: 91 13 54 
-      negative-color: 353 70 65 
-      accent-color: 199 19 62 
-    
-    kanso-ink:
-      background-color: 220 18 10 
-      primary-color: 150 4 78 
-      positive-color: 91 13 54 
-      negative-color: 353 70 65 
-      accent-color: 199 19 62 
 pages:
   - name: Home
     columns:
@@ -105,7 +90,7 @@ pages:
           - type: server-stats
             servers:
               - type: local
-                name: "srv-geisha"
+                name: "srv-hatchi"
                 hide-mountpoints-by-default: true
                 mountpoints:
                   "/":
@@ -113,11 +98,8 @@ pages:
                   "/mnt/data":
                     hide: false
               - type: remote
-                name: "srv-hatchi"
-                url: ${DOKPLOY_HOST}
-              - type: remote
                 name: "srv-nana"
-                url: ${OLLAMA_HOST}
+                url: http://${OLLAMA_HOST}
       - size: full
         widgets:
           - type: monitor
@@ -126,43 +108,43 @@ pages:
             sites:
               - title: Jellyfin
                 url: https://media.${DOMAIN}
-                icon: /assets/jellyfin.svg
+                icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/jellyfin.svg
               - title: Portainer
                 url: https://portainer.${DOMAIN}
-                icon: /assets/portainer.svg
+                icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/portainer.svg
               - title: Jellyseerr
                 url: https://jellyseerr.${DOMAIN}
-                icon: /assets/jellyseerr.svg
+                icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/jellyseerr.svg
               - title: Komga
                 url: https://library.${DOMAIN}
-                icon: /assets/komga.svg
+                icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/komga.svg
               - title: Nextcloud
                 url: https://drive.${DOMAIN}
-                icon: /assets/nextcloud.svg
+                icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/nextcloud.svg
               - title: Radarr
                 url: https://radarr.${DOMAIN}
-                icon: /assets/radarr.svg
+                icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/radarr.svg
               - title: Sonarr
                 url: https://sonarr.${DOMAIN}
-                icon: /assets/sonarr.svg
+                icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/sonarr.svg
               - title: Suwayomi
                 url: https://manga.${DOMAIN}
-                icon: /assets/suwayomi.svg
+                icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/suwayomi.svg
               - title: Cockpit
                 url: https://admin.${DOMAIN}
-                icon: /assets/cockpit.svg
+                icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/cockpit.svg
               - title: Prowlarr
                 url: https://prowlarr.${DOMAIN}
-                icon: /assets/prowlarr.svg
+                icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/prowlarr.svg
               - title: AdGuard Home
                 url: https://adguard.${DOMAIN}
-                icon: /assets/adguard-home.svg
+                icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/adguard-home.svg
               - title: Dokploy
                 url: https://dokploy.${DOMAIN}
-                icon: /assets/dokploy.svg
+                icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/dokploy.svg
               - title: Ollama
                 url: https://ollama.${DOMAIN}
-                icon: /assets/ollama.svg
+                icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/ollama.svg
 
           - type: docker-containers
             title: Homelab containers

--- a/glance/config/glance.yml
+++ b/glance/config/glance.yml
@@ -95,8 +95,6 @@ pages:
                 mountpoints:
                   "/":
                     hide: false
-                  "/mnt/data":
-                    hide: false
               - type: remote
                 name: "srv-nana"
                 url: http://${OLLAMA_HOST}
@@ -145,10 +143,6 @@ pages:
               - title: Ollama
                 url: https://ollama.${DOMAIN}
                 icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/ollama.svg
-
-          - type: docker-containers
-            title: Homelab containers
-            hide-by-default: false
 
       - size: small
         widgets:


### PR DESCRIPTION
## What
This PR migrates the homelab server architecture from 3 servers to 2 servers. The main atomic change is the consolidation and migration of services—especially Podman-managed FOSS containers and DNS—onto the remaining active servers, along with configuration adjustments across several files.  

## How
- Updated `docker-compose.yml` to remove references and mountpoints related to the decommissioned server, unify asset paths, and adjust service definitions to reflect new server roles.
- Modified the `Caddyfile` to update the Dokploy reverse proxy target to use `host.docker.internal`.
- Added a new file, `adguard/AdGuardHome.yaml`, to version-control AdGuard Home's configuration to ensure DNS service continuity and reproducibility.
- Refactored `glance/config/glance.yml` by removing unused themes, updating widget/server names, and switching to CDN-hosted SVG icons for homelab service dashboards. Simplified widget layout and improved clarity for server stats and site shortcuts.

## Why 
One of the original 3 servers failed, prompting architecture simplification. Merging services (FOSS with Podman, custom/hobby with Dokploy) onto 2 remaining machines.