### PR TITLE
Refactor/selinux docker

### DIFF
--- a/.todo
+++ b/.todo
@@ -35,7 +35,7 @@ Fix my server:
   ✘ Fix the docker containers widget on glance @cancelled(25-08-28 22:21)
   ✔ Add nextcloud back onto podman network @started(25-08-28 22:22) @done(25-09-01 04:05) @lasted(3d5h43m54s)
   ✔ Fix docker socket permissions @started(25-09-01 04:11) @done(25-09-02 17:53) @lasted(1d13h42m44s)
-  - Clean up selinux dokploy installation
+  ✔ Clean up selinux dokploy installation @started(25-09-02 18:19) @done(25-09-02 18:48) @lasted(29m29s)
   - Setup portainer agent again on srv-nana
   - Fix the containers randomly stopping for a problem, maybe caddy or nextcloud
   - Make sure find a solution for nextcloud containers to also start up even if they are not started by master

--- a/scripts/redo-dokploy.sh
+++ b/scripts/redo-dokploy.sh
@@ -8,15 +8,18 @@ if [ "$(id -u)" != "0" ]; then
     exit 1
 fi
 
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Check if install script exists
-if [ ! -f "./install-dokploy.sh" ]; then
-    echo "❌ install-dokploy.sh not found in current directory"
+if [ ! -f "$SCRIPT_DIR/install-dokploy.sh" ]; then
+    echo "❌ install-dokploy.sh not found in $SCRIPT_DIR"
     exit 1
 fi
 
 # Check if cleanup script exists
-if [ ! -f "./cleanup-dokploy.sh" ]; then
-    echo "❌ cleanup-dokploy.sh not found in current directory"
+if [ ! -f "$SCRIPT_DIR/cleanup-dokploy.sh" ]; then
+    echo "❌ cleanup-dokploy.sh not found in $SCRIPT_DIR"
     exit 1
 fi
 
@@ -27,7 +30,7 @@ echo "📍 Using advertise address: $ADVERTISE_ADDR"
 # Run cleanup
 echo ""
 echo "🧹 Step 1: Cleaning up existing installation..."
-./cleanup-dokploy.sh
+"$SCRIPT_DIR/cleanup-dokploy.sh"
 
 # Wait a moment for cleanup to complete
 sleep 2
@@ -35,7 +38,7 @@ sleep 2
 # Run installation
 echo ""
 echo "🚀 Step 2: Installing Dokploy fresh..."
-./install-dokploy.sh
+"$SCRIPT_DIR/install-dokploy.sh"
 
 echo ""
 echo "🎉 Dokploy reinstallation completed!"


### PR DESCRIPTION
## What
This PR refactors and streamlines SELinux policy setup in Dokploy installation scripts.

## How
- In `scripts/install-dokploy.sh`, consolidated SELinux policy setup by:
  - Replacing host-specific policy module generation with a single consistent `dockersock` policy, loaded if available.
  - Adding clearer paths for applying SELinux file contexts for `/etc/dokploy` using `semanage` and `restorecon`.
  - Cleaning up checks for `checkmodule`, `semanage`, and adjusting log output.
  - Removed legacy Traefik/MLS policy workflow.
- In `scripts/redo-dokploy.sh`, updated references to install/cleanup scripts to use absolute paths by determining `SCRIPT_DIR`, ensuring the scripts are invoked from any directory context.

## Why 
The previous approach used more complex, non-portable SELinux policy generation and installation for Docker and Traefik, occasionally producing redundant/unused modules and potential confusion around container access controls.