### PR TITLE
Feat/obsidian live sync

### DIFF
--- a/.todo
+++ b/.todo
@@ -52,7 +52,8 @@ Fix my server:
     ✔ Find a manga downloader (suwayomi if it can work) @done(25-09-04 17:00)
     ✔ Fix komga to work with manga downloader @done(25-09-04 17:00)
     ✔ Add manga client on ios from komga server @done(25-09-04 17:00)
-  - Add obsidian live sync server @started(25-09-04 21:09)
+  ✔ Add obsidian live sync server @started(25-09-04 21:09) @done(25-09-05 00:38) @lasted(3h29m55s)
+  ✔ Add ports with .env @started(25-09-05 00:39) @done(25-09-05 00:48) @lasted(9m27s)
   - Create glance agent with go to setup remote server connections
   - Test containers if you need both user and userns in compose
   - Setup ollama models on srv-nana and test with raycast ai

--- a/Caddyfile
+++ b/Caddyfile
@@ -115,6 +115,14 @@ qbittorrent.{env.DOMAIN} {
 	}
 }
 
+# CouchDB service (for Obsidian Live Sync)
+couchdb.{env.DOMAIN} {
+	reverse_proxy couchdb-for-ols:5984
+	tls {
+		dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+	}
+}
+
 # Cockpit (proxy to host)
 admin.{env.DOMAIN} {
 	reverse_proxy host.docker.internal:{env.COCKPIT_PORT} {

--- a/adguard/AdGuardHome.yaml
+++ b/adguard/AdGuardHome.yaml
@@ -179,6 +179,8 @@ filtering:
       answer: 192.168.200.70
     - domain: portainer.chateauducipieres.com
       answer: 192.168.200.70
+    - domain: couchdb.chateauducipieres.com
+      answer: 192.168.200.70
   safe_fs_patterns:
     - /opt/adguardhome/work/userfilters/*
   safebrowsing_cache_size: 1048576

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,9 +44,9 @@ services:
     networks:
       - caddynet
     ports:
-      - "80:80"
-      - "443:443"
-      - "443:443/udp"
+      - "${CADDY_HTTP_PORT}:${CADDY_DOCKER_HTTP_PORT}"
+      - "${CADDY_HTTPS_PORT}:${CADDY_DOCKER_HTTPS_PORT}"
+      - "${CADDY_HTTPS_PORT}:${CADDY_DOCKER_HTTPS_PORT}/udp"
     env_file:
       - .env
     environment:
@@ -134,7 +134,7 @@ services:
       - media_manga:/home/suwayomi/.local/share/Tachidesk/downloads:z
       - suwayomi_config:/home/suwayomi/.local/share/Tachidesk:z
     ports:
-      - "4567:4567"
+      - ${SUWAYOMI_PORT}:${SUWAYOMI_DOCKER_PORT}
 
   jellyfin:
     image: jellyfin/jellyfin
@@ -284,8 +284,8 @@ services:
     security_opt:
       - label=disable
     ports:
-      - "8000:8000"
-      - "9443:9443"
+      - ${PORTAINER_HTTP_PORT}:${PORTAINER_HTTP_DOCKER_PORT}
+      - ${PORTAINER_HTTPS_PORT}:${PORTAINER_HTTPS_DOCKER_PORT}
     volumes:
       - /run/user/1000/podman/podman.sock:/var/run/docker.sock:Z
       - portainer_data:/data
@@ -358,7 +358,7 @@ services:
       - couchdb_data:/opt/couchdb/data:Z
       - couchdb_config:/opt/couchdb/etc/local.d:Z
     ports:
-      - 5984:5984
+      - ${COUCHDB_PORT}:${COUCHDB_DOCKER_PORT}
     restart: unless-stopped
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -347,6 +347,19 @@ services:
     volumes:
         - nextcloud_aio_mastercontainer:/mnt/docker-aio-config:Z
         - /run/user/1000/podman/podman.sock:/var/run/docker.sock:Z
+  couchdb:
+    image: couchdb:latest
+    container_name: couchdb-for-ols
+    user: 5984:5984
+    environment:
+      - COUCHDB_USER=${COUCHDB_USER}
+      - COUCHDB_PASSWORD=${COUCHDB_PASSWORD}
+    volumes:
+      - couchdb_data:/opt/couchdb/data:Z
+      - couchdb_config:/opt/couchdb/etc/local.d:Z
+    ports:
+      - 5984:5984
+    restart: unless-stopped
 
 networks:
   caddynet:
@@ -379,3 +392,5 @@ volumes:
     external: true
   nextcloud_aio_mastercontainer:
     external: true
+  couchdb_data:
+  couchdb_config:

--- a/glance/config/glance.yml
+++ b/glance/config/glance.yml
@@ -146,6 +146,9 @@ pages:
               - title: Ollama
                 url: https://ollama.${DOMAIN}
                 icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/ollama.svg
+              - title: CouchDB
+                url: https://couchdb.${DOMAIN}
+                icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/couchdb.svg
 
       - size: small
         widgets:


### PR DESCRIPTION
## What

Add and configure a CouchDB service to support Obsidian Live Sync integration.

## How

- Defined a new service `couchdb` in `docker-compose.yml`, set user, environment variables, ports using `.env`, mapped volumes, and joined the correct network.
- Updated port mappings and other service ports across `docker-compose.yml` to use environment variables.
- In `Caddyfile`, included a reverse proxy definition for CouchDB, enabled TLS, and integrated Cloudflare DNS.
- Added `couchdb.chateauducipieres.com` to the AdGuard Home DNS config, pointing to the internal network IP.
- Registered CouchDB as a quick link and icon in the Glance dashboard YAML.
- Updated `.todo` to reflect completion of the Obsidian Live Sync server goal.

## Why

Now I can sync my notes across devices.
