### PR TITLE
feat: add GPU support for Jellyfin service in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -156,6 +156,8 @@ services:
       - jellyfin_cache:/cache:Z
       - media_movies:/movies:z
       - media_tvshows:/tvshows:z
+    devices: 
+      - nvidia.com/gpu=0
     ports:
       - ${JELLYFIN_PORT}:${JELLYFIN_DOCKER_PORT}
 


### PR DESCRIPTION
## What

Added hardware acceleration to use my nvidia gpu on my server to not use 95% of my cpu for `ffmpeg

## How

Modified `docker-compose.yml`:
- Within the `services` section for Jellyfin, added:
  ```
  devices:
    - nvidia.com/gpu=0
  ```

## Why

Allocating the NVIDIA GPU specifically to the Jellyfin service ensures that hardware acceleration is properly enabled for video transcoding, leveraging the host GPU for improved media performance and offloading computation from the CPU.