### PR TITLE
Fix/ollama-setup

### DIFF
--- a/srv-nana/docker-compose.yml
+++ b/srv-nana/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - "11434:11434"
     volumes:
-      - ollama:/root/.ollama
+      - models:/root/.ollama
     restart: always
     networks:
       - nana-net
@@ -21,7 +21,6 @@ services:
 volumes:
   data:
   models:
-  ollama:
 networks:
   nana-net:
     driver: bridge


### PR DESCRIPTION
## What

Refactored the `srv-nana/docker-compose.yml` file to update the volume mapping for the `ollama` service. The volume was changed from `ollama:/root/.ollama` to `models:/root/.ollama`.

## How

- Modified the `volumes` section under the `ollama` service in `srv-nana/docker-compose.yml`:
  - Replaced the old mapping
    - `- ollama:/root/.ollama`
  - With the new mapping
    - `- models:/root/.ollama`
- Removed the `ollama` volume definition and ensured `models` is defined.

## Why

- This change standardizes the volume name for model storage by using `models` instead of `ollama` in `srv-nana/docker-compose.yml`.
- It provides clearer intent and consistency in service configuration, aligning volume naming with its usage for storing AI models.

## TONOTE

- **NVIDIA Container Toolkit Installation:** The setup requires installing the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) to enable GPU access in containers.
- **SELinux Configuration:** SELinux policy modifications may be needed to allow relevant container flags for GPU access, ensuring models can leverage GPU resources within the containerized environment:

```
container_connect_any --> on
container_manage_cgroup --> on
container_use_devices --> on
container_use_dri_devices --> on
container_use_xserver_devices --> on
container_user_exec_content --> on
```

