### PR TITLE
Feat/grafana

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -123,6 +123,14 @@ couchdb.{env.DOMAIN} {
 	}
 }
 
+# Grafana service
+grafana.{env.DOMAIN} {
+	reverse_proxy grafana:{env.GRAFANA_DOCKER_PORT}
+	tls {
+		dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+	}
+}
+
 # Cockpit (proxy to host)
 admin.{env.DOMAIN} {
 	reverse_proxy host.docker.internal:{env.COCKPIT_PORT} {

--- a/adguard/AdGuardHome.yaml
+++ b/adguard/AdGuardHome.yaml
@@ -181,6 +181,8 @@ filtering:
       answer: 192.168.200.70
     - domain: couchdb.chateauducipieres.com
       answer: 192.168.200.70
+    - domain: grafana.chateauducipieres.com
+      answer: 192.168.200.70
   safe_fs_patterns:
     - /opt/adguardhome/work/userfilters/*
   safebrowsing_cache_size: 1048576

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -372,6 +372,44 @@ services:
     volumes:
       - grafana_storage:/var/lib/grafana
 
+  node-exporter:
+    image: prom/node-exporter:latest
+    container_name: node-exporter
+    restart: unless-stopped
+    networks:
+      - caddynet
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.rootfs=/rootfs'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+    expose:
+      - ${NODE_EXPORTER_PORT}
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    restart: unless-stopped
+    networks:
+      - caddynet
+    env_file:
+      - .env
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:Z
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+      - '--web.enable-lifecycle'
+    expose:
+      - ${PROMETHEUS_PORT}
+
 networks:
   caddynet:
     external: true
@@ -406,3 +444,4 @@ volumes:
   couchdb_data:
   couchdb_config:
   grafana_storage:
+  prometheus_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -362,6 +362,15 @@ services:
     ports:
       - ${COUCHDB_PORT}:${COUCHDB_DOCKER_PORT}
     restart: unless-stopped
+  
+  grafana:
+    image: grafana/grafana-enterprise
+    container_name: grafana
+    restart: unless-stopped
+    ports:
+      - "${GRAFANA_PORT}:${GRAFANA_DOCKER_PORT}"
+    volumes:
+      - grafana_storage:/var/lib/grafana
 
 networks:
   caddynet:
@@ -396,3 +405,4 @@ volumes:
     external: true
   couchdb_data:
   couchdb_config:
+  grafana_storage:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -371,6 +371,8 @@ services:
       - "${GRAFANA_PORT}:${GRAFANA_DOCKER_PORT}"
     volumes:
       - grafana_storage:/var/lib/grafana
+    networks:
+      - caddynet
 
   node-exporter:
     image: prom/node-exporter:latest

--- a/glance/config/glance.yml
+++ b/glance/config/glance.yml
@@ -149,6 +149,9 @@ pages:
               - title: CouchDB
                 url: https://couchdb.${DOMAIN}
                 icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/couchdb.svg
+              - title: Grafana
+                url: https://grafana.${DOMAIN}
+                icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/grafana.svg
 
       - size: small
         widgets:

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -11,7 +11,6 @@ scrape_configs:
     static_configs:
       - targets: ['node-exporter:9100']
 
-  # Remote server scraping
   - job_name: 'srv-nana-node'
     static_configs:
       - targets: ['192.168.200.182:9100']

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,19 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    scrape_interval: 1m
+    static_configs:
+      - targets: ['prometheus:9090']
+
+  - job_name: 'node'
+    static_configs:
+      - targets: ['node-exporter:9100']
+
+  # Remote server scraping
+  - job_name: 'srv-nana-node'
+    static_configs:
+      - targets: ['192.168.200.182:9100']
+    scrape_interval: 30s
+    metrics_path: /metrics

--- a/srv-nana/docker-compose.yml
+++ b/srv-nana/docker-compose.yml
@@ -27,6 +27,24 @@ services:
     ports:
       - "8080:8080"
 
+  node-exporter:
+    image: prom/node-exporter:latest
+    container_name: node-exporter
+    restart: unless-stopped
+    networks:
+      - nana-net
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.rootfs=/rootfs'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+    ports:
+      - "9100:9100"
+
 
 volumes:
   data:


### PR DESCRIPTION
### What
This PR adds a baseline observability stack with Grafana, Prometheus, and Node Exporter

### How
- Services are containerized and managed with Podman Compose, consistent with the repo
- Ports are configured via `${...}` environment variables to match your style
- Prometheus uses `--web.enable-lifecycle` and persists TSDB to `prometheus_data`
- `node-exporter` mounts host `/proc`, `/sys`, and rootfs read-only; exposes metrics on `${NODE_EXPORTER_PORT}`
- Grafana stores state in `grafana_storage` and is currently exposed via host port (not yet behind Caddy)

### Why
- Establishes a minimal, reproducible observability baseline for metrics and dashboards
- Enables system metrics for the host and a remote node, supporting future expansion