### PR TITLE
Fix/nextcloud podman socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,21 @@
-# TODO
+# Homelab
 
-- [x] Need to add the dns server ip to be persistent
-- [x] Add portainer to docker compose
-- [x] Add dokploy on other server to caddy net
-- [x] Setup dokploy
-- [x] Add dokploy to glance.yml
-- [x] Add dokploy to portainer
-- [ ] Add ollama to big server
-- [ ] Add grafana for data monitoring
-- [ ] Move adguard config to this repo instead
-- [ ] Setup DNS for second computer
-- [ ] Setup other computer and deploy dokploy and gh self hosted runner
-- [ ] Fix big computer and setup ssh keys for it and tailscale access.
+## About the project
 
-# Planned for the future
+This repo is my config for my homelab running all my self-hosted instances that I plan to maintain and expand in the coming years.
+
+I started this to learn more about devops, linux, and the power of taking control of your software.
+
+## Planned for the future
 
 - Find a better way to manage secrets for all the servers (duplicate .envs for all of them right now)
 - Automated configuration using ansible
 - Proper CI/CD with github actions to apply changes to infra in one place
+- Ansible updates for fedora kernel, container updates, gpu updates with container runtime
 - K3s for automatic load balancing and better managmenet across computers
 
-Hey.
 
-This is my home server for the chateau.
-
-Will update more soon :).
-
-I just added 2 more computers.
-
-# Additional configurations
+## Additional configurations
 
 - Provide sufficient privilleges for containers if you are running SELinux
 - Opened up the ports 53, 80, 433 on my server for dns / http / https
@@ -42,27 +29,7 @@ sudo nmcli connection modify "adguard-dns" ipv4.dns "192.168.200.69 1.1.1.1" ipv
 dns_bind_port = 1153
 ```
 
-# Limitations
+## Limitations
 
 - If you want to add a new service you need to add a new domain in the adguard dns rewrites for caddy to work
 - No config on adguard home
-
-# DNS
-
-## Upstream DNS
-
-```
-https://dns10.quad9.net/dns-query
-https://dns.adguard-dns.com/dns-query
-https://cloudflare-dns.com/dns-query
-https://dns.google/dns-query
-https://dns10.quad9.net/dns-query
-94.140.14.14
-94.140.15.15
-1.1.1.1
-1.0.0.1
-8.8.8.8
-8.8.4.4
-9.9.9.9
-149.112.112.112
-```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -346,9 +346,11 @@ services:
         - APACHE_IP_BINDING=0.0.0.0
         - SKIP_DOMAIN_VALIDATION=true
         - APACHE_ADDITIONAL_NETWORK=caddynet
+        - NEXTCLOUD_ENABLE_NVIDIA_GPU=true
+        - WATCHTOWER_DOCKER_SOCKET_PATH=/run/user/1000/podman/podman.sock
     volumes:
         - nextcloud_aio_mastercontainer:/mnt/docker-aio-config:Z
-        - /run/user/1000/podman/podman.sock:/var/run/docker.sock:Z
+        - /run/user/1000/podman/podman.sock:/var/run/docker.sock:z
   couchdb:
     image: couchdb:latest
     container_name: couchdb-for-ols


### PR DESCRIPTION
## What 

This PR fixes the nextcloud watchtower podman socket access for updates through the UI and adds nvidia gpu access to nextcloud container for hardware acceleration.

I’ll draft the PR description based on the diff you provided for `README.md` and `docker-compose.yml`.

## How
 - `docker-compose.yml` (Nextcloud AIO service):
 - Add env var `NEXTCLOUD_ENABLE_NVIDIA_GPU=true` to opt-in to GPU acceleration.
 - Add env var `WATCHTOWER_DOCKER_SOCKET_PATH=/run/user/1000/podman/podman.sock` for Podman socket compatibility.
 - Change bind option on the Podman socket mount from `:Z` to `:z` to allow shared SELinux relabeling with other containers/processes:
 - Keep existing AIO settings (e.g., `SKIP_DOMAIN_VALIDATION=true`, `APACHE_*` vars) unchanged.

## Why
- Prepare Nextcloud AIO for GPU-enabled features (e.g., media processing/AI enhancements), aligning with the homelab’s learning and expansion goals.
- Ensure Watchtower and related tooling operate correctly under Podman by pointing to the correct user socket and appropriate SELinux relabel mode.